### PR TITLE
Compatibility with dev dbplyr

### DIFF
--- a/R/cql-translate.R
+++ b/R/cql-translate.R
@@ -49,7 +49,7 @@ cql_translate <- function(...) {
     if (packageVersion("dbplyr") <= "2.1.1") {
       rlang::new_quosure(dbplyr::partial_eval(x, vars = character()), rlang::get_env(x))
     } else {
-      rlang::new_quosure(dbplyr::partial_eval(x, .data = dbplyr::lazy_frame()), rlang::get_env(x))
+      rlang::new_quosure(dbplyr::partial_eval(x, data = dbplyr::lazy_frame()), rlang::get_env(x))
     }
   })
   

--- a/R/cql-translate.R
+++ b/R/cql-translate.R
@@ -45,8 +45,12 @@ cql_translate <- function(...) {
         )
       }
     }
-    
-    rlang::new_quosure(dbplyr::partial_eval(x), rlang::get_env(x))
+
+    if (packageVersion("dbplyr") <= "2.1.1") {
+      rlang::new_quosure(dbplyr::partial_eval(x, vars = character()), rlang::get_env(x))
+    } else {
+      rlang::new_quosure(dbplyr::partial_eval(x, .data = dbplyr::lazy_frame()), rlang::get_env(x))
+    }
   })
   
   sql_where <- dbplyr::translate_sql_(dots, con = wfs_con, window = FALSE)


### PR DESCRIPTION
We are updating `dbplyr::partial_eval()`. It now requires `.data` as second argument in order to correctly evaluate calls like `across()`. We noticed in revdeps that the tests of this package now fail. This PR makes the package compatible with the CRAN and the dev version of dbplyr.

By the way: When testing your package I noticed that the lines 43 to 45 in `cql-translate.R` are never run in your tests:

```r
x <- rlang::call_modify(
  x, !!call_arg := rlang::call2("local", rlang::call_args(x)[[call_arg]])
)
```

If they are actually required you might want to add a test for this.